### PR TITLE
Kein Whitespace, wenn es keine Equipments gibt

### DIFF
--- a/src/Dashboard/Dashboard.sass
+++ b/src/Dashboard/Dashboard.sass
@@ -1,22 +1,10 @@
 @import '../_basic'
 
 .Dashboard 
-    .BTN_TEST_CREATE
-        position: absolute
-        bottom: 1rem
-        left: 1rem
-        background: red
-        padding: 1rem
-        color: $white
-        font-size: 1rem
-        border: none
-        border-radius: 10px
-        cursor: pointer
-    
     main
         display: flex
         position: absolute
-        gap: 5rem
+        gap: 10rem
         top: 50%
         left: 50%
         transform: translate(-50%, -50%)

--- a/src/Dashboard/Equipment/Equipment.sass
+++ b/src/Dashboard/Equipment/Equipment.sass
@@ -3,13 +3,14 @@
 .Equipment
     .contents
         margin-top: 2rem
-        width: 70rem
-        display: grid
-        grid-template-columns: repeat(3, 20rem)
-        max-height: calc(2 * 25rem + 2rem + 12px)
-        gap: 2rem
         overflow-y: auto
-        padding: 6px 0 6px 0
+        padding-top: 6px
+        display: grid
+        grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr))
+        gap: 2rem
+
+        max-width: calc(3 * 20rem + 2 * 2rem) // Maximal 3 Spalten + 2 Gaps
+        width: 100%
         @media screen and (max-width: 1920px)
             max-height: calc(25rem + 2rem + 12px)
 


### PR DESCRIPTION
Obwohl nur ein oder zwei Equipments gespeichert, wurde der Whitespace für drei Spalten angezeigt. Das wurde gefixt