### PR TITLE
Modal für kleinere Bildschirme bei PlaceRO

### DIFF
--- a/src/Header/Header.sass
+++ b/src/Header/Header.sass
@@ -5,6 +5,7 @@ header
     align-items: center
     padding-left: 2rem
     padding-right: 2rem
+    z-index: 100
     .link
         color: black
         text-decoration: none

--- a/src/PlaceRO/FloorPlanEquipment/FloorPlanEquipment.sass
+++ b/src/PlaceRO/FloorPlanEquipment/FloorPlanEquipment.sass
@@ -1,6 +1,8 @@
 @import '../../_basic'
 
 .FloorPlanEquipment
+    @media screen and (max-width: 1900px)
+        display: none !important
     .description
         text-align: center
     .equipment-slider

--- a/src/PlaceRO/FloorPlanEquipmentModal/FloorPlanEquipmentModal.jsx
+++ b/src/PlaceRO/FloorPlanEquipmentModal/FloorPlanEquipmentModal.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import './FloorPlanEquipmentModal.sass';
+import { collection, getDocs, query } from 'firebase/firestore';
+import { db } from '../../firebase/firebase';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faClose } from '@fortawesome/free-solid-svg-icons';
+
+const FloorPlanEquipmentModal = ({ data, setMobileModalShow }) => {
+
+    const [color, setColor] = useState(data.data.color);
+
+    const selectedCategory = data.data.category;
+
+    const [equipmentList, setEquipmentList] = useState([]);
+    const [otherEquipmentList, setOtherEquipmentList] = useState([]);
+
+    const [disableSave, setDisableSave] = useState(false);
+
+    const [currentEquipmentSelection, setCurrentEquipmentSelection] = useState(0);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            const q = query(collection(db, "equipment"));
+
+            const querySnapshot = await getDocs(q);
+
+            const dbData = querySnapshot.docs.map(el => ({ id: el.id, ...el.data() }));
+
+            const equipment = dbData.filter(el => el.id == data.data.selectedEquipment)[0];
+            
+            console.log('AKTUELLES EQUIPMENT: ');
+            console.log(equipment);
+            console.log('-------------------------------------');
+
+            setCurrentEquipmentSelection(equipment);
+        };
+
+        fetchData();   
+    }, []);
+
+    return <div className="FloorPlanEquipmentModal" style={{
+        display: data.showOptions ? 'flex' : 'none'
+    }}>
+        <FontAwesomeIcon className='close-icon' onClick={() => {
+            setMobileModalShow(false);
+            data.showOptions = false;
+        }} icon={faClose} />
+        <div className="equipment-slider">
+            <div className="card">
+                {selectedCategory == 0  ? 
+                    (currentEquipmentSelection ? <div className='equipment-item'>
+                        <h3>{currentEquipmentSelection.title}</h3>
+
+                        <div className="img-container">
+                            {currentEquipmentSelection.contents.topBarAdd ? <img className='top-bar-add' src={currentEquipmentSelection.contents.topBarAdd} /> : null}
+                            {currentEquipmentSelection.contents.topBar ? <img className='top-bar' src={currentEquipmentSelection.contents.topBar} /> : null}
+                            {currentEquipmentSelection.contents.foot ? <img className='foot' src={currentEquipmentSelection.contents.foot} /> : null}
+                            <div className="lights">
+                                <div className="light-container">
+                                    {currentEquipmentSelection.contents.light01 ? <img className='light-01' src={currentEquipmentSelection.contents.light01} /> : null}
+                                    {currentEquipmentSelection.contents.light02 ? <img className='light-02' src={currentEquipmentSelection.contents.light02} /> : null}
+                                </div>
+                                {currentEquipmentSelection.contents.light03 ? <img className='light-03' src={currentEquipmentSelection.contents.light03} /> : null}
+                                <div className="light-container">
+                                    {currentEquipmentSelection.contents.light04 ? <img className='light-04' src={currentEquipmentSelection.contents.light04} /> : null}
+                                    {currentEquipmentSelection.contents.light05 ? <img className='light-05' src={currentEquipmentSelection.contents.light05} /> : null}
+                                </div>
+                            </div>
+                        </div>
+                    </div> : null) : 
+                    (currentEquipmentSelection != null ? <div className='equipment-item-other-cat'>
+                        <h3>{currentEquipmentSelection.title}</h3>
+
+                        <div className="img-container-other-cat">
+                            <img className='other-category-img' src={currentEquipmentSelection?.contents?.img || ''} />
+                        </div>
+                    </div> : null)
+                }
+            </div>
+        </div>
+
+        <div>
+            <div className='description'>
+                <h3>Beschreibung</h3>
+                <p>{selectedCategory == 0 && currentEquipmentSelection != null ? 
+                    (currentEquipmentSelection.description == '' ? 
+                        'Keine Beschreibung enthalten...' : currentEquipmentSelection.description) : 
+                    (currentEquipmentSelection != null ? 
+                        (currentEquipmentSelection.description == '' ? 
+                            'Keine Beschreibung enthalten...' : currentEquipmentSelection.description) : null)}</p>
+            </div>
+        </div>
+
+        <div>
+            <div className="color-selection">
+                <label htmlFor='color'>Farbe</label>
+                <div className="color-select-container">
+                    <input onInput={e => {
+                        setColor(e.target.value);
+                        data.data.color = color;
+                        console.log(data);
+                    }} type='text' id='color' value={color} readOnly />
+                    <div className="color-represent" style={{background: color}}></div>
+                </div>
+            </div>
+        </div>
+    </div>
+};
+
+export default FloorPlanEquipmentModal;

--- a/src/PlaceRO/FloorPlanEquipmentModal/FloorPlanEquipmentModal.sass
+++ b/src/PlaceRO/FloorPlanEquipmentModal/FloorPlanEquipmentModal.sass
@@ -1,0 +1,114 @@
+@import '../../_basic'
+
+.FloorPlanEquipmentModal
+    position: absolute
+    background: $white
+    z-index: 200
+    left: 50%
+    top: 50%
+    transform: translate(-50%, -50%)
+    padding: 2rem
+    height: 75vh
+    border-radius: 1rem
+    flex-direction: column
+    justify-content: space-between
+    @media screen and (min-width: 1900px)
+        display: none !important
+    @media screen and (max-height: 930px)
+        height: 85vh
+    @media screen and (max-height: 820px)
+        height: 95vh
+    .close-icon
+        position: absolute
+        top: 2rem
+        right: 2rem
+        font-size: 1.3rem
+        cursor: pointer
+        z-index: 200
+    .equipment-item-other-cat
+        display: flex
+        justify-content: center
+        flex-direction: column
+        .img-container-other-cat, .img-container
+            img
+                max-height: 45vh
+                margin-top: 1rem
+    .equipment-item
+        width: 100%
+        position: relative
+        height: 32rem
+        border-radius: 1rem
+        display: flex
+        flex-direction: column
+        gap: 1rem
+        h3
+            text-align: center
+        .img-container
+            position: relative
+            transform: scale(0.8)
+            .top-bar-add, .foot, .top-bar
+                position: absolute
+
+            .foot
+                height: 435px
+                width: 140px
+                top: 203px
+                left: 50%
+                transform: translate(-50%, -65px)
+
+            .top-bar-add
+                width: 410px
+                height: 65px
+                top: 0
+                left: 50%
+                transform: translateX(-50%)
+
+            .top-bar
+                top: 65px
+                height: 73px
+                width: 510px
+                left: 50%
+                transform: translateX(-50%)
+                z-index: 100
+
+            .lights
+                position: absolute
+                top: 138px
+                display: flex
+                width: 510px
+                left: 50%
+                transform: translateX(-50%)
+                justify-content: space-around
+                z-index: 10
+                .light, img
+                    position: relative
+                    height: 110px
+                    width: 90px
+                .light-container
+                    display: flex
+
+    .color-selection
+            gap: 1rem
+            position: relative
+            display: flex
+            label
+                display: flex
+                align-items: center
+                gap: 1rem
+            .color-select-container
+                display: flex
+                input
+                    height: 2rem
+                    padding: .8rem
+                    height: 2rem
+                    width: 10rem
+                    border-radius: 10px 0 0 10px
+                    border: none
+                    background: $gray
+                    outline: none
+                .color-represent
+                    height: 2rem
+                    width: 2rem
+                    border-radius: 0 10px 10px 0
+                    pointer-events: all
+        

--- a/src/PlaceRO/PlaceRO.jsx
+++ b/src/PlaceRO/PlaceRO.jsx
@@ -12,10 +12,10 @@ import { doc, getDoc, query, setDoc } from 'firebase/firestore';
 import { useNavigate, useParams } from 'react-router-dom';
 import { db } from '../firebase/firebase';
 import FloorPlanEquipment from './FloorPlanEquipment/FloorPlanEquipment';
+import FloorPlanEquipmentModal from './FloorPlanEquipmentModal/FloorPlanEquipmentModal';
 
 
 const PlaceRO = () => {
-    const containerRef = useRef();
     const floorPlanRef = useRef();
     const { id } = useParams();
 
@@ -24,6 +24,8 @@ const PlaceRO = () => {
     const [floorPlan, setFloorPlan] = useState();
     const [imgSrc, setImgSrc] = useState('');
     const [equipmentPlacements, setEquipmentPlacements] = useState();
+
+    const [mobileModalShow, setMobileModalShow] = useState(false);
 
     useEffect(() => {
         const fetchFloorPlan = async () => {
@@ -62,15 +64,21 @@ const PlaceRO = () => {
         });
     
         setEquipmentPlacements(tempPlaces);
+        setMobileModalShow(true);
     }
 
-    return (
+    return floorPlan ? (
         <div className="PlaceRO">
-            {floorPlan ? <div>
+            <Header pageName={floorPlan.name} />
+            
+            {!equipmentPlacements.every(({ showOptions }) => !showOptions) ? equipmentPlacements.map(equipment => {
+                return <FloorPlanEquipmentModal setMobileModalShow={setMobileModalShow} data={equipment}/>
+            }) : null}
 
-                <Header pageName={floorPlan.name} />
+            {mobileModalShow ? <div className='blur'></div> : null}
 
-                <div className="bottom-container">
+            <main>
+                <div className="bottom-container" style={floorPlanRef.current ? {height: floorPlanRef.current.getBoundingClientRect().height} : null}>
                     <div className='layout'>
                         <div>
                             <img ref={floorPlanRef} src={imgSrc} className="floor-plan-img" onLoad={() => setEquipmentContainerLoaded(true)}  />
@@ -83,7 +91,7 @@ const PlaceRO = () => {
                                 top: '50%',
                                 transform: 'translate(-50%, -50%)',
                                 zIndex: 200
-                            }} ref={containerRef}>                    
+                            }}>                    
                                 {equipmentPlacements.map(equipment => {
                                     const rect = floorPlanRef.current.getBoundingClientRect();
                                     const absoluteX = equipment.x * rect.width;
@@ -96,8 +104,6 @@ const PlaceRO = () => {
                                             onClick={equipmentClickEvent}
                                             style={{
                                                 position: 'absolute',
-                                                height: '2vw',
-                                                width: '2vw',
                                                 borderRadius: '100%',
                                                 background: equipment.data.color,
                                                 left: absoluteX - 24,
@@ -116,7 +122,7 @@ const PlaceRO = () => {
                     {equipmentPlacements ? <div className="layout-item-select">
                         <div className='current-selection'>
                             {!equipmentPlacements.every(({ showOptions }) => !showOptions) ? equipmentPlacements.map(equipment => {
-                                return <FloorPlanEquipment data={equipment}/>
+                                return <FloorPlanEquipment setMobileModalShow={setMobileModalShow} data={equipment}/>
                             }) : 
                             <div className='no-selection'>
                                 <h1>Auswahl</h1>
@@ -128,11 +134,11 @@ const PlaceRO = () => {
                 </div>
 
                 
-            </div> : null}
+            </main>
 
             <Footer />
         </div>
-    )
+    ) : null;
 }
 
 export default PlaceRO;

--- a/src/PlaceRO/PlaceRO.sass
+++ b/src/PlaceRO/PlaceRO.sass
@@ -1,5 +1,15 @@
 @import '../_basic'
-
+    
+.blur
+    position: absolute
+    top: 0
+    left: 0
+    height: 100vh
+    width: 100vw
+    background-color: rgba(0, 0, 0, .5)
+    @media screen and (min-width: 1900px)
+        display: none !important
+    
 .PlaceRO
     .bottom-container
         position: absolute
@@ -7,23 +17,22 @@
         transform: translateY(-50%)
         display: flex
         justify-content: center
-        gap: 12rem
         width: 100vw
-        height: 80vh
-        @media screen and (max-width: 1900px)
-            gap: 0
+        @media screen and (max-width: 2000px)
+            gap: 4rem
         @media screen and (max-width: 1200px)
             align-items: center
         .floor-plan-entry
-            @media screen and (max-width: 1200px) 
-                height: 3vw !important
-                width: 3vw !important
+            height: 2.5rem
+            width: 2.5rem
+            transform: translate(5px, 5px)
         .layout
             position: relative
             width: 60%
             height: 100%
             .floor-plan-img
-                max-height: 100%
+                max-height: 70vh
+                max-width: 70vw
                 display: block
                 z-index: 100
                 object-fit: contain
@@ -62,7 +71,8 @@
                 height: 100%
                 display: flex
                 flex-direction: column
+                align-items: flex-start
                 gap: 2rem
-            @media screen and (max-width: 1900px)
-                display: none
+                @media screen and (max-width: 1900px)
+                    display: none
 

--- a/src/PlaceRO/PlaceRO.sass
+++ b/src/PlaceRO/PlaceRO.sass
@@ -10,8 +10,10 @@
         gap: 12rem
         width: 100vw
         height: 80vh
-        @media screen and (max-width: 1200px)
+        @media screen and (max-width: 1900px)
             gap: 0
+        @media screen and (max-width: 1200px)
+            align-items: center
         .floor-plan-entry
             @media screen and (max-width: 1200px) 
                 height: 3vw !important
@@ -27,7 +29,7 @@
                 object-fit: contain
                 border: 3px solid $gray
                 border-radius: 1rem
-                @media screen and (max-width: 1200px) 
+                @media screen and (max-width: 1900px) 
                     border: none
                     border-radius: 0
             input
@@ -61,6 +63,6 @@
                 display: flex
                 flex-direction: column
                 gap: 2rem
-            @media screen and (max-width: 1200px)
+            @media screen and (max-width: 1900px)
                 display: none
 


### PR DESCRIPTION
Bei der Readonly Ansicht der Party Orte, wird nun ein auf zu kleinen Bildschirmen ein Modal mit aktuellen Auswahl erzeugt, anstatt rechts das ausgewählte Equipment anzuzeigen.