### PR TITLE
Container-Breite der FloorPlanEquipments gefixt

### DIFF
--- a/src/PlaceRO/FloorPlanEquipment/FloorPlanEquipment.sass
+++ b/src/PlaceRO/FloorPlanEquipment/FloorPlanEquipment.sass
@@ -17,7 +17,7 @@
             &:hover
                 color: $primary
         .card
-            width: 100%
+            width: 510px
             display: flex
             flex-direction: column
             gap: 2rem

--- a/src/PlaceRO/FloorPlanEquipmentModal/FloorPlanEquipmentModal.sass
+++ b/src/PlaceRO/FloorPlanEquipmentModal/FloorPlanEquipmentModal.sass
@@ -45,6 +45,8 @@
             text-align: center
         .img-container
             position: relative
+            width: 510px
+            margin-top: 2rem
             transform: scale(0.8)
             .top-bar-add, .foot, .top-bar
                 position: absolute


### PR DESCRIPTION
Ursprünglich war der Equipment-Container bei der PlaceRO Ansicht zu klein.
Hier hatte die Feste Breite gefehlt, die anhand der Breite der Top-Bar (510px) festgemacht wurde.